### PR TITLE
Extract run-stream client out of Home

### DIFF
--- a/client/src/hooks/useRunSimulation.ts
+++ b/client/src/hooks/useRunSimulation.ts
@@ -1,0 +1,144 @@
+import { createSignal, onCleanup } from "solid-js";
+import type { Activity, AgentResult } from "../types";
+import {
+  openRunStream,
+  RunStreamHttpError,
+  RunStreamUnauthorizedError,
+  type RunStreamEvent,
+  type RunStreamInput,
+} from "../lib/runStream";
+
+export type UseRunSimulationOptions = {
+  onSaved?: (id: string) => void;
+  onUnauthorized?: () => void;
+};
+
+export function useRunSimulation(opts: UseRunSimulationOptions = {}) {
+  const [loading, setLoading] = createSignal(false);
+  const [error, setError] = createSignal<string | null>(null);
+  const [activity, setActivity] = createSignal<Activity[]>([]);
+  const [doneAgents, setDoneAgents] = createSignal<AgentResult[]>([]);
+  const [logCollapsed, setLogCollapsed] = createSignal(false);
+  const [remainingSec, setRemainingSec] = createSignal<number | null>(null);
+
+  let timerHandle: ReturnType<typeof setInterval> | undefined;
+  const stopTimer = () => {
+    if (timerHandle !== undefined) {
+      clearInterval(timerHandle);
+      timerHandle = undefined;
+    }
+    setRemainingSec(null);
+  };
+  const startTimer = (totalSec: number) => {
+    stopTimer();
+    const deadline = Date.now() + totalSec * 1000;
+    setRemainingSec(totalSec);
+    timerHandle = setInterval(() => {
+      const left = Math.max(0, Math.ceil((deadline - Date.now()) / 1000));
+      setRemainingSec(left);
+      if (left <= 0 && timerHandle !== undefined) {
+        clearInterval(timerHandle);
+        timerHandle = undefined;
+      }
+    }, 250);
+  };
+
+  const handleEvent = (event: RunStreamEvent) => {
+    switch (event.name) {
+      case "activity":
+        setActivity((arr) => [...arr, event.data]);
+        return;
+      case "agent-done":
+        setDoneAgents((arr) => [...arr, event.data]);
+        return;
+      case "simulation-complete":
+        stopTimer();
+        setActivity((arr) => [
+          ...arr,
+          {
+            kind: "phase",
+            label: `Simulation complete — ${event.data.posts} posts, ${event.data.comments} comments`,
+            tone: "success",
+          },
+        ]);
+        return;
+      case "report-start":
+        setActivity((arr) => [
+          ...arr,
+          { kind: "phase", label: "Writing report…", tone: "info" },
+        ]);
+        return;
+      case "report-done":
+        if (event.data.markdown) {
+          setActivity((arr) => [
+            ...arr,
+            { kind: "phase", label: "Report ready", tone: "success" },
+          ]);
+        } else {
+          setActivity((arr) => [
+            ...arr,
+            {
+              kind: "phase",
+              label: `Report skipped${event.data.error ? `: ${event.data.error}` : ""}`,
+              tone: "info",
+            },
+          ]);
+        }
+        return;
+      case "error":
+        setError(event.data.error ?? "unknown error");
+        return;
+      case "start":
+      case "saved":
+      case "done":
+        return;
+    }
+  };
+
+  const run = async (input: RunStreamInput) => {
+    setLoading(true);
+    setError(null);
+    setActivity([
+      { kind: "phase", label: "Starting simulation…", tone: "start" },
+    ]);
+    setDoneAgents([]);
+    setLogCollapsed(false);
+    startTimer(input.durationSec);
+
+    let savedId: string | null = null;
+    try {
+      for await (const event of openRunStream(input)) {
+        if (event.name === "saved") {
+          savedId = event.data.id;
+        }
+        handleEvent(event);
+      }
+      if (savedId) opts.onSaved?.(savedId);
+    } catch (err) {
+      if (err instanceof RunStreamUnauthorizedError) {
+        opts.onUnauthorized?.();
+        setError(err.message);
+      } else if (err instanceof RunStreamHttpError) {
+        setError(err.message);
+      } else {
+        setError(err instanceof Error ? err.message : String(err));
+      }
+    } finally {
+      stopTimer();
+      setLoading(false);
+    }
+  };
+
+  onCleanup(stopTimer);
+
+  return {
+    loading,
+    error,
+    activity,
+    doneAgents,
+    logCollapsed,
+    setLogCollapsed,
+    remainingSec,
+    run,
+  };
+}

--- a/client/src/lib/runStream.ts
+++ b/client/src/lib/runStream.ts
@@ -1,0 +1,105 @@
+import type { Activity, AgentResult, SimulationResult } from "../types";
+
+export type RunStreamInput = {
+  source: string;
+  encryptedKey: string;
+  agentCount: number;
+  maxStepsPerAgent: number;
+  durationSec: number;
+  mode: "requeue" | "random";
+  persistentMemory: boolean;
+  modelId?: string | null;
+};
+
+export type RunStreamEvent =
+  | { name: "start"; data: { agentCount: number } }
+  | { name: "activity"; data: Activity }
+  | { name: "agent-done"; data: AgentResult }
+  | { name: "simulation-complete"; data: { posts: number; comments: number } }
+  | { name: "report-start"; data: Record<string, unknown> }
+  | { name: "report-done"; data: { markdown: string | null; error?: string } }
+  | { name: "saved"; data: { id: string } }
+  | { name: "done"; data: SimulationResult }
+  | { name: "error"; data: { error: string } };
+
+export class RunStreamUnauthorizedError extends Error {
+  constructor() {
+    super("Saved key was rejected — re-enter your OpenRouter key.");
+    this.name = "RunStreamUnauthorizedError";
+  }
+}
+
+export class RunStreamHttpError extends Error {
+  status: number;
+  constructor(status: number, body: string) {
+    super(`${status}: ${body}`);
+    this.name = "RunStreamHttpError";
+    this.status = status;
+  }
+}
+
+function parseChunk(chunk: string): RunStreamEvent | null {
+  const eventLine = chunk.match(/^event:\s*(.*)$/m);
+  const dataLine = chunk.match(/^data:\s*(.*)$/m);
+  if (!eventLine || !dataLine) return null;
+  const name = eventLine[1].trim();
+  let data: unknown;
+  try {
+    data = JSON.parse(dataLine[1]);
+  } catch {
+    return null;
+  }
+  switch (name) {
+    case "start":
+    case "activity":
+    case "agent-done":
+    case "simulation-complete":
+    case "report-start":
+    case "report-done":
+    case "saved":
+    case "done":
+    case "error":
+      return { name, data } as RunStreamEvent;
+    default:
+      return null;
+  }
+}
+
+export async function* openRunStream(
+  input: RunStreamInput,
+): AsyncGenerator<RunStreamEvent> {
+  const res = await fetch("/api/run-stream", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      source: input.source,
+      encryptedKey: input.encryptedKey,
+      agentCount: input.agentCount,
+      maxStepsPerAgent: input.maxStepsPerAgent,
+      durationSec: input.durationSec,
+      mode: input.mode,
+      persistentMemory: input.persistentMemory,
+      ...(input.modelId ? { modelId: input.modelId } : {}),
+    }),
+  });
+  if (res.status === 401) throw new RunStreamUnauthorizedError();
+  if (!res.ok || !res.body) {
+    const body = await res.text();
+    throw new RunStreamHttpError(res.status, body);
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = "";
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    let idx: number;
+    while ((idx = buffer.indexOf("\n\n")) !== -1) {
+      const chunk = buffer.slice(0, idx);
+      buffer = buffer.slice(idx + 2);
+      const event = parseChunk(chunk);
+      if (event) yield event;
+    }
+  }
+}

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -15,7 +15,6 @@ import {
   TbOutlineHeartbeat,
   TbOutlineKey,
 } from "solid-icons/tb";
-import type { Activity, AgentResult } from "../types";
 import { formatDuration } from "../lib/format";
 import Logo from "../components/Logo";
 import ActivityFeed from "../components/ActivityFeed";
@@ -23,6 +22,7 @@ import KeyGate from "../components/KeyGate";
 import ModelPicker from "../components/ModelPicker";
 import { clearStoredKey, getStoredKey, type StoredKey } from "../lib/keyStore";
 import { getStoredModel, setStoredModel } from "../lib/modelStore";
+import { useRunSimulation } from "../hooks/useRunSimulation";
 
 const SAMPLE_SOURCE = `BREAKING: Chinese AI lab DeepSeek released a new open-weights model that scores within 2 points of GPT-5 on standard benchmarks while costing roughly 1/30th to train. The release dropped overnight on Hugging Face with a permissive license. Western labs are reportedly scrambling to respond.`;
 
@@ -39,8 +39,6 @@ export default function Home() {
 
   const [keyBlob, setKeyBlob] = createSignal<StoredKey | null>(getStoredKey());
   const [modelId, setModelIdInternal] = createSignal<string | null>(getStoredModel());
-  const [loading, setLoading] = createSignal(false);
-  const [error, setError] = createSignal<string | null>(null);
 
   const setModelId = (id: string | null) => {
     setModelIdInternal(id);
@@ -51,143 +49,36 @@ export default function Home() {
     clearStoredKey();
     setKeyBlob(null);
   };
-  const [activity, setActivity] = createSignal<Activity[]>([]);
-  const [doneAgents, setDoneAgents] = createSignal<AgentResult[]>([]);
-  const [logCollapsed, setLogCollapsed] = createSignal(false);
-  const [remainingSec, setRemainingSec] = createSignal<number | null>(null);
 
-  let timerHandle: ReturnType<typeof setInterval> | undefined;
-  const stopTimer = () => {
-    if (timerHandle !== undefined) {
-      clearInterval(timerHandle);
-      timerHandle = undefined;
-    }
-    setRemainingSec(null);
-  };
-  const startTimer = (totalSec: number) => {
-    stopTimer();
-    const deadline = Date.now() + totalSec * 1000;
-    setRemainingSec(totalSec);
-    timerHandle = setInterval(() => {
-      const left = Math.max(0, Math.ceil((deadline - Date.now()) / 1000));
-      setRemainingSec(left);
-      if (left <= 0 && timerHandle !== undefined) {
-        clearInterval(timerHandle);
-        timerHandle = undefined;
-      }
-    }, 250);
-  };
+  const {
+    loading,
+    error,
+    activity,
+    doneAgents,
+    logCollapsed,
+    setLogCollapsed,
+    remainingSec,
+    run,
+  } = useRunSimulation({
+    onSaved: (id) => navigate(`/v/${id}`),
+    onUnauthorized: resetKey,
+  });
 
-  const submit = async () => {
+  const submit = () => {
     const text = source().trim();
     if (!text) return;
     const stored = keyBlob();
     if (!stored) return;
-    setLoading(true);
-    setError(null);
-    setActivity([
-      { kind: "phase", label: "Starting simulation…", tone: "start" },
-    ]);
-    setDoneAgents([]);
-    setLogCollapsed(false);
-    startTimer(durationSec());
-
-    try {
-      const res = await fetch("/api/run-stream", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          source: text,
-          encryptedKey: stored.encryptedKey,
-          agentCount: agentCount(),
-          maxStepsPerAgent: maxStepsPerAgent(),
-          durationSec: durationSec(),
-          mode: mode(),
-          persistentMemory: persistentMemory(),
-          ...(modelId() ? { modelId: modelId() } : {}),
-        }),
-      });
-      if (res.status === 401) {
-        resetKey();
-        throw new Error("Saved key was rejected — re-enter your OpenRouter key.");
-      }
-      if (!res.ok || !res.body) {
-        const body = await res.text();
-        throw new Error(`${res.status}: ${body}`);
-      }
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-      let savedId: string | null = null;
-      while (true) {
-        const { value, done } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        let idx: number;
-        while ((idx = buffer.indexOf("\n\n")) !== -1) {
-          const chunk = buffer.slice(0, idx);
-          buffer = buffer.slice(idx + 2);
-          const eventLine = chunk.match(/^event:\s*(.*)$/m);
-          const dataLine = chunk.match(/^data:\s*(.*)$/m);
-          if (!eventLine || !dataLine) continue;
-          const name = eventLine[1].trim();
-          let data: any;
-          try {
-            data = JSON.parse(dataLine[1]);
-          } catch {
-            continue;
-          }
-          if (name === "activity") {
-            setActivity((arr) => [...arr, data as Activity]);
-          } else if (name === "agent-done") {
-            setDoneAgents((arr) => [...arr, data as AgentResult]);
-          } else if (name === "simulation-complete") {
-            stopTimer();
-            setActivity((arr) => [
-              ...arr,
-              {
-                kind: "phase",
-                label: `Simulation complete — ${data.posts} posts, ${data.comments} comments`,
-                tone: "success",
-              },
-            ]);
-          } else if (name === "report-start") {
-            setActivity((arr) => [
-              ...arr,
-              { kind: "phase", label: "Writing report…", tone: "info" },
-            ]);
-          } else if (name === "report-done") {
-            if (data.markdown) {
-              setActivity((arr) => [
-                ...arr,
-                { kind: "phase", label: "Report ready", tone: "success" },
-              ]);
-            } else {
-              setActivity((arr) => [
-                ...arr,
-                {
-                  kind: "phase",
-                  label: `Report skipped${data.error ? `: ${data.error}` : ""}`,
-                  tone: "info",
-                },
-              ]);
-            }
-          } else if (name === "saved") {
-            savedId = data.id;
-          } else if (name === "error") {
-            setError(data.error ?? "unknown error");
-          }
-        }
-      }
-      if (savedId) {
-        navigate(`/v/${savedId}`);
-      }
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-    } finally {
-      stopTimer();
-      setLoading(false);
-    }
+    void run({
+      source: text,
+      encryptedKey: stored.encryptedKey,
+      agentCount: agentCount(),
+      maxStepsPerAgent: maxStepsPerAgent(),
+      durationSec: durationSec(),
+      mode: mode(),
+      persistentMemory: persistentMemory(),
+      modelId: modelId(),
+    });
   };
 
   return (


### PR DESCRIPTION
Closes #5

## Summary

`client/src/pages/Home.tsx` was parsing raw `ReadableStream` chunks, switching on string event names, and managing the live-run timer alongside form state. Pulled the protocol + orchestration out so the page can stay focused on form + layout.

- `client/src/lib/runStream.ts` — owns request construction, SSE chunk parsing, and yields a discriminated `RunStreamEvent` union via `openRunStream()`. Typed `RunStreamUnauthorizedError` / `RunStreamHttpError` so callers can branch instead of string-matching error messages.
- `client/src/hooks/useRunSimulation.ts` — owns live run state: `activity`, `doneAgents`, `logCollapsed`, `remainingSec`, the countdown timer (cleared in `onCleanup`), and `onSaved` / `onUnauthorized` callbacks.
- `Home.tsx` — keeps form state + layout, calls `run(...)`. Durable prefs (`keyStore`, `modelStore`) stayed where they were.

## Acceptance criteria

- [x] No raw `ReadableStream` parsing in `Home.tsx`
- [x] No string-name event switch in `Home.tsx`
- [x] No `let data: any`; payloads are typed via the `RunStreamEvent` union
- [x] UI behavior unchanged: activity feed, timer, report phases, `/v/:id` redirect, 401 key reset
- [x] `npm run build` passes in `client/`

## Test plan

- [ ] `cd client && npm run build` (passes locally)
- [ ] Run a simulation end-to-end: live activity log + countdown render, redirect to `/v/:id` after `saved`
- [ ] Stale/invalid stored key returns 401 → `KeyGate` re-prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)