### PR TITLE
Extract shared run/report/persist pipeline from HTTP routes

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,12 +2,8 @@ import "dotenv/config";
 import express from "express";
 import cors from "cors";
 import { z } from "zod";
-import { randomUUID } from "node:crypto";
-import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import { loadProfiles } from "./profiles.js";
-import { runSimulation, DEFAULT_MODEL_ID } from "./runSimulation.js";
-import { generateReport, type ReportResult } from "./report.js";
-import type { ActivityEvent } from "./tools.js";
+import { runPipeline } from "./runPipeline.js";
 import prisma from "./resources/prisma.js";
 import cryptr from "./resources/cryptr.js";
 import { encryptedKeySchema } from "./encryptedKey.js";
@@ -142,10 +138,10 @@ app.post("/api/run", async (req, res) => {
       .status(400)
       .json({ error: "invalid request", detail: parsed.error.issues });
   }
-  const opts = parsed.data;
+  const { encryptedKey, ...request } = parsed.data;
   let resolved: { apiKey: string; mode: "user" | "admin" };
   try {
-    resolved = resolveApiKey(opts.encryptedKey);
+    resolved = resolveApiKey(encryptedKey);
   } catch (err) {
     if (err instanceof ResolveKeyError) {
       return res.status(401).json({ error: err.message });
@@ -153,97 +149,21 @@ app.post("/api/run", async (req, res) => {
     throw err;
   }
   console.log(
-    `▶ /api/run [${resolved.mode}]: agents=${opts.agentCount} duration=${opts.durationSec}s mode=${opts.mode} source="${opts.source.slice(0, 80).replace(/\s+/g, " ")}…"`
+    `▶ /api/run [${resolved.mode}]: agents=${request.agentCount} duration=${request.durationSec}s mode=${request.mode} source="${request.source.slice(0, 80).replace(/\s+/g, " ")}…"`
   );
   try {
-    const activity: ActivityEvent[] = [
-      { kind: "phase", label: "Starting simulation…", tone: "start" },
-    ];
-    const result = await runSimulation({
-      ...opts,
-      pool: profiles,
+    const final = await runPipeline({
+      request,
+      profiles,
       apiKey: resolved.apiKey,
-      onActivity: (e) => activity.push(e),
     });
-    activity.push({
-      kind: "phase",
-      label: `Simulation complete — ${result.totals.posts} posts, ${result.totals.comments} comments`,
-      tone: "success",
-    });
-    activity.push({ kind: "phase", label: "Writing report…", tone: "info" });
-    const reportModel = createOpenRouter({ apiKey: resolved.apiKey }).chat(opts.modelId ?? DEFAULT_MODEL_ID);
-    const report = await generateReport({
-      model: reportModel,
-      source: opts.source,
-      snapshot: result.snapshot,
-    });
-    activity.push({
-      kind: "phase",
-      label: report.markdown
-        ? "Report ready"
-        : `Report skipped${report.error ? `: ${report.error}` : ""}`,
-      tone: report.markdown ? "success" : "info",
-    });
-    const finalTotals = addReportCost(result.totals, report);
-    const id = await persistRun({
-      opts,
-      result,
-      activity,
-      reportMarkdown: report.markdown,
-      totals: finalTotals,
-    });
-    res.json({
-      id,
-      ...result,
-      report: report.markdown,
-      totals: finalTotals,
-    });
+    res.json(final);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error("simulation failed:", msg);
     res.status(500).json({ error: msg });
   }
 });
-
-function addReportCost(
-  totals: { costUsd: number; inputTokens: number; outputTokens: number; posts: number; comments: number; elapsedMs: number },
-  report: ReportResult
-) {
-  return {
-    ...totals,
-    costUsd: totals.costUsd + report.costUsd,
-    inputTokens: totals.inputTokens + report.tokens.input,
-    outputTokens: totals.outputTokens + report.tokens.output,
-  };
-}
-
-async function persistRun(args: {
-  opts: z.infer<typeof requestSchema>;
-  result: Awaited<ReturnType<typeof runSimulation>>;
-  activity: ActivityEvent[];
-  reportMarkdown: string | null;
-  totals: ReturnType<typeof addReportCost>;
-}): Promise<string> {
-  const id = randomUUID();
-  await prisma.run.create({
-    data: {
-      id,
-      source: args.opts.source,
-      agentCount: args.opts.agentCount,
-      maxStepsPerAgent: args.opts.maxStepsPerAgent,
-      durationSec: args.opts.durationSec,
-      mode: args.opts.mode,
-      persistentMemory: args.opts.persistentMemory,
-      participants: JSON.stringify(args.result.participants),
-      agentResults: JSON.stringify(args.result.agentResults),
-      snapshot: JSON.stringify(args.result.snapshot),
-      activity: JSON.stringify(args.activity),
-      report: args.reportMarkdown,
-      totals: JSON.stringify(args.totals),
-    },
-  });
-  return id;
-}
 
 // Streaming variant: emit each ActivityEvent + final result as a Server-Sent
 // Events stream so the client can render comments arriving live.
@@ -254,10 +174,10 @@ app.post("/api/run-stream", async (req, res) => {
       .status(400)
       .json({ error: "invalid request", detail: parsed.error.issues });
   }
-  const opts = parsed.data;
+  const { encryptedKey, ...request } = parsed.data;
   let resolved: { apiKey: string; mode: "user" | "admin" };
   try {
-    resolved = resolveApiKey(opts.encryptedKey);
+    resolved = resolveApiKey(encryptedKey);
   } catch (err) {
     if (err instanceof ResolveKeyError) {
       return res.status(401).json({ error: err.message });
@@ -274,62 +194,20 @@ app.post("/api/run-stream", async (req, res) => {
     res.write(`data: ${JSON.stringify(data)}\n\n`);
   };
 
-  send("start", { agentCount: opts.agentCount });
+  send("start", { agentCount: request.agentCount });
   try {
-    const activity: ActivityEvent[] = [
-      { kind: "phase", label: "Starting simulation…", tone: "start" },
-    ];
-    const result = await runSimulation({
-      ...opts,
-      pool: profiles,
+    const final = await runPipeline({
+      request,
+      profiles,
       apiKey: resolved.apiKey,
-      onActivity: (e) => {
-        activity.push(e);
-        send("activity", e);
-      },
+      onActivity: (e) => send("activity", e),
       onAgentDone: (r) => send("agent-done", r),
+      onSimulationComplete: (info) => send("simulation-complete", info),
+      onReportStart: () => send("report-start", {}),
+      onReportDone: (info) => send("report-done", info),
+      onSaved: (info) => send("saved", info),
     });
-    send("simulation-complete", {
-      posts: result.totals.posts,
-      comments: result.totals.comments,
-    });
-    activity.push({
-      kind: "phase",
-      label: `Simulation complete — ${result.totals.posts} posts, ${result.totals.comments} comments`,
-      tone: "success",
-    });
-    send("report-start", {});
-    activity.push({ kind: "phase", label: "Writing report…", tone: "info" });
-    const reportModel = createOpenRouter({ apiKey: resolved.apiKey }).chat(opts.modelId ?? DEFAULT_MODEL_ID);
-    const report = await generateReport({
-      model: reportModel,
-      source: opts.source,
-      snapshot: result.snapshot,
-    });
-    send("report-done", { markdown: report.markdown, error: report.error });
-    activity.push({
-      kind: "phase",
-      label: report.markdown
-        ? "Report ready"
-        : `Report skipped${report.error ? `: ${report.error}` : ""}`,
-      tone: report.markdown ? "success" : "info",
-    });
-    const finalTotals = addReportCost(result.totals, report);
-    const id = await persistRun({
-      opts,
-      result,
-      activity,
-      reportMarkdown: report.markdown,
-      totals: finalTotals,
-    });
-    send("saved", { id });
-    const finalResult = {
-      id,
-      ...result,
-      report: report.markdown,
-      totals: finalTotals,
-    };
-    send("done", finalResult);
+    send("done", final);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     send("error", { error: msg });

--- a/server/src/runPipeline.ts
+++ b/server/src/runPipeline.ts
@@ -1,0 +1,175 @@
+import { randomUUID } from "node:crypto";
+import { createOpenRouter } from "@openrouter/ai-sdk-provider";
+import {
+  runSimulation,
+  DEFAULT_MODEL_ID,
+  type PublicAgentResult,
+  type SimulationResult,
+} from "./runSimulation.js";
+import { generateReport, type ReportResult } from "./report.js";
+import type { ActivityEvent } from "./tools.js";
+import type { Profile } from "./profiles.js";
+import prisma from "./resources/prisma.js";
+
+export interface PipelineRequest {
+  source: string;
+  agentCount: number;
+  maxStepsPerAgent: number;
+  durationSec: number;
+  mode: "requeue" | "random";
+  persistentMemory: boolean;
+  modelId?: string;
+}
+
+export interface PipelineCallbacks {
+  // Forwarded from runSimulation — every state-changing tool call plus the
+  // abort-circuit "Stopped" phase. The synthesized lifecycle phases
+  // (Starting / Simulation complete / Writing report / Report ready) are
+  // recorded into the persisted activity log but NOT sent here, since the
+  // SSE route delivers them via dedicated event types.
+  onActivity?: (event: ActivityEvent) => void;
+  onAgentDone?: (result: PublicAgentResult) => void;
+  onSimulationComplete?: (info: { posts: number; comments: number }) => void;
+  onReportStart?: () => void;
+  onReportDone?: (info: { markdown: string | null; error?: string }) => void;
+  onSaved?: (info: { id: string }) => void;
+}
+
+export interface PipelineOptions extends PipelineCallbacks {
+  request: PipelineRequest;
+  profiles: Profile[];
+  apiKey: string;
+}
+
+type Totals = SimulationResult["totals"];
+
+export interface PipelineResult extends Omit<SimulationResult, "totals"> {
+  id: string;
+  report: string | null;
+  totals: Totals;
+}
+
+function addReportCost(totals: Totals, report: ReportResult): Totals {
+  return {
+    ...totals,
+    costUsd: totals.costUsd + report.costUsd,
+    inputTokens: totals.inputTokens + report.tokens.input,
+    outputTokens: totals.outputTokens + report.tokens.output,
+  };
+}
+
+async function persistRun(args: {
+  request: PipelineRequest;
+  result: SimulationResult;
+  activity: ActivityEvent[];
+  reportMarkdown: string | null;
+  totals: Totals;
+}): Promise<string> {
+  const id = randomUUID();
+  await prisma.run.create({
+    data: {
+      id,
+      source: args.request.source,
+      agentCount: args.request.agentCount,
+      maxStepsPerAgent: args.request.maxStepsPerAgent,
+      durationSec: args.request.durationSec,
+      mode: args.request.mode,
+      persistentMemory: args.request.persistentMemory,
+      participants: JSON.stringify(args.result.participants),
+      agentResults: JSON.stringify(args.result.agentResults),
+      snapshot: JSON.stringify(args.result.snapshot),
+      activity: JSON.stringify(args.activity),
+      report: args.reportMarkdown,
+      totals: JSON.stringify(args.totals),
+    },
+  });
+  return id;
+}
+
+// The shared run/report/persist flow. Both /api/run and /api/run-stream
+// call this — the streaming route wires up the callbacks to translate
+// each phase into SSE events, while the JSON route omits them and just
+// awaits the final result.
+export async function runPipeline(opts: PipelineOptions): Promise<PipelineResult> {
+  const {
+    request,
+    profiles,
+    apiKey,
+    onActivity,
+    onAgentDone,
+    onSimulationComplete,
+    onReportStart,
+    onReportDone,
+    onSaved,
+  } = opts;
+
+  const activity: ActivityEvent[] = [
+    { kind: "phase", label: "Starting simulation…", tone: "start" },
+  ];
+
+  const result = await runSimulation({
+    source: request.source,
+    pool: profiles,
+    apiKey,
+    agentCount: request.agentCount,
+    maxStepsPerAgent: request.maxStepsPerAgent,
+    durationSec: request.durationSec,
+    mode: request.mode,
+    persistentMemory: request.persistentMemory,
+    modelId: request.modelId,
+    onActivity: (e) => {
+      activity.push(e);
+      onActivity?.(e);
+    },
+    onAgentDone: (r) => onAgentDone?.(r),
+  });
+
+  onSimulationComplete?.({
+    posts: result.totals.posts,
+    comments: result.totals.comments,
+  });
+  activity.push({
+    kind: "phase",
+    label: `Simulation complete — ${result.totals.posts} posts, ${result.totals.comments} comments`,
+    tone: "success",
+  });
+
+  onReportStart?.();
+  activity.push({ kind: "phase", label: "Writing report…", tone: "info" });
+
+  const reportModel = createOpenRouter({ apiKey }).chat(
+    request.modelId ?? DEFAULT_MODEL_ID
+  );
+  const report = await generateReport({
+    model: reportModel,
+    source: request.source,
+    snapshot: result.snapshot,
+  });
+
+  onReportDone?.({ markdown: report.markdown, error: report.error });
+  activity.push({
+    kind: "phase",
+    label: report.markdown
+      ? "Report ready"
+      : `Report skipped${report.error ? `: ${report.error}` : ""}`,
+    tone: report.markdown ? "success" : "info",
+  });
+
+  const finalTotals = addReportCost(result.totals, report);
+  const id = await persistRun({
+    request,
+    result,
+    activity,
+    reportMarkdown: report.markdown,
+    totals: finalTotals,
+  });
+
+  onSaved?.({ id });
+
+  return {
+    id,
+    ...result,
+    report: report.markdown,
+    totals: finalTotals,
+  };
+}


### PR DESCRIPTION
Closes #6

## Summary

`server/src/index.ts` had two endpoints — `/api/run` and `/api/run-stream` — that owned independent copies of the same flow: seed activity log, run simulation, append lifecycle phase strings, generate report, fold report cost into totals, persist the row, and shape the final result. The streaming route layered SSE sends on top, but the pipeline was the same.

This PR centralizes that flow in a new `server/src/runPipeline.ts`. The pipeline owns the activity log, the four synthesized lifecycle phases (Starting / Simulation complete / Writing report / Report ready), the report generation, the `addReportCost` arithmetic, the `prisma.run.create` write, and the final-result shape. It exposes optional callbacks (`onActivity`, `onAgentDone`, `onSimulationComplete`, `onReportStart`, `onReportDone`, `onSaved`) so the SSE route can translate each phase into its existing dedicated event type. The JSON route omits the callbacks and just awaits the return value.

`runSimulation()` stays free of HTTP/persistence concerns; only the route handlers and the new pipeline module talk to Express and Prisma.

## Acceptance criteria
- [x] The run/report/persist flow exists in one place (`runPipeline.ts`).
- [x] `/api/run` and `/api/run-stream` no longer duplicate report generation, totals math, or persistence calls.
- [x] Existing API responses and SSE event sequence remain compatible (same shape and same order: `start → activity* → agent-done* → simulation-complete → report-start → report-done → saved → done`, plus `error` on throw).
- [x] Server tests pass (`npm test` — 32 tests).
- [x] Server typecheck passes (`npx tsc -p tsconfig.json --noEmit`).

## Test plan
- [ ] `cd server && npm test` (vitest, 32 tests)
- [ ] `cd server && npx tsc -p tsconfig.json --noEmit`
- [ ] Smoke test the JSON route: `POST /api/run` returns `{ id, source, participants, agentResults, snapshot, report, totals }` and the row appears in `dev.db`.
- [ ] Smoke test the SSE route: `POST /api/run-stream` emits `start`, then `activity` + `agent-done` events during the run, then `simulation-complete`, `report-start`, `report-done`, `saved`, `done` (in that order). On error: `error`.
- [ ] Open `/v/:id` after a streamed run — the saved activity log replays the same lifecycle phases the live user saw.

🤖 Generated with [Claude Code](https://claude.com/claude-code)