### PR TITLE
Add shared/ contracts module for run API and stream events

### DIFF
--- a/client/src/lib/runStream.ts
+++ b/client/src/lib/runStream.ts
@@ -1,4 +1,8 @@
-import type { Activity, AgentResult, SimulationResult } from "../types";
+import {
+  isRunStreamEventName,
+  type RunStreamEvent,
+  type RunStreamEventMap,
+} from "../../../shared/contracts";
 
 export type RunStreamInput = {
   source: string;
@@ -11,16 +15,7 @@ export type RunStreamInput = {
   modelId?: string | null;
 };
 
-export type RunStreamEvent =
-  | { name: "start"; data: { agentCount: number } }
-  | { name: "activity"; data: Activity }
-  | { name: "agent-done"; data: AgentResult }
-  | { name: "simulation-complete"; data: { posts: number; comments: number } }
-  | { name: "report-start"; data: Record<string, unknown> }
-  | { name: "report-done"; data: { markdown: string | null; error?: string } }
-  | { name: "saved"; data: { id: string } }
-  | { name: "done"; data: SimulationResult }
-  | { name: "error"; data: { error: string } };
+export type { RunStreamEvent, RunStreamEventMap };
 
 export class RunStreamUnauthorizedError extends Error {
   constructor() {
@@ -43,26 +38,16 @@ function parseChunk(chunk: string): RunStreamEvent | null {
   const dataLine = chunk.match(/^data:\s*(.*)$/m);
   if (!eventLine || !dataLine) return null;
   const name = eventLine[1].trim();
+  if (!isRunStreamEventName(name)) return null;
   let data: unknown;
   try {
     data = JSON.parse(dataLine[1]);
   } catch {
     return null;
   }
-  switch (name) {
-    case "start":
-    case "activity":
-    case "agent-done":
-    case "simulation-complete":
-    case "report-start":
-    case "report-done":
-    case "saved":
-    case "done":
-    case "error":
-      return { name, data } as RunStreamEvent;
-    default:
-      return null;
-  }
+  // The server emits payloads matching RunStreamEventMap[name]; we trust the
+  // contract here rather than re-validating each shape on the client.
+  return { name, data } as RunStreamEvent;
 }
 
 export async function* openRunStream(

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,105 +1,21 @@
-export type Post = {
-  id: string;
-  authorUsername: string;
-  title: string;
-  body: string;
-  createdAt: number;
-};
-
-export type CommentNode = {
-  id: string;
-  authorUsername: string;
-  body: string;
-  createdAt: number;
-  parentId: string;
-  karma: number;
-  upvotes: number;
-  downvotes: number;
-  replies: CommentNode[];
-};
-
-export type Snapshot = {
-  posts: Array<{
-    post: Post;
-    karma: number;
-    upvotes: number;
-    downvotes: number;
-    comments: CommentNode[];
-  }>;
-  exportedAt: number;
-};
-
-export type Participant = {
-  username: string;
-  name: string;
-  occupation: string;
-  location: string;
-};
-
-export type AgentResult = {
-  username: string;
-  steps: number;
-  finishReason: string | null;
-  costUsd: number;
-  tokens: { input: number; output: number };
-  errored: boolean;
-  error?: string;
-};
-
-export type Totals = {
-  costUsd: number;
-  inputTokens: number;
-  outputTokens: number;
-  posts: number;
-  comments: number;
-  elapsedMs: number;
-};
-
-export type SimulationResult = {
-  id?: string;
-  source: string;
-  participants: Participant[];
-  agentResults: AgentResult[];
-  snapshot: Snapshot;
-  report?: string | null;
-  totals: Totals;
-};
-
-export type Activity =
-  | { kind: "post-created"; postId: string; username: string; title: string }
-  | {
-      kind: "comment-created";
-      commentId: string;
-      postId: string;
-      parentId: string;
-      username: string;
-      body: string;
-    }
-  | {
-      kind: "vote";
-      entityId: string;
-      username: string;
-      type: "up" | "down";
-      result: string;
-    }
-  | { kind: "tool-error"; tool: string; username: string; error: string }
-  | { kind: "phase"; label: string; tone: "info" | "success" | "start" | "error" };
-
-export type RunRecord = {
-  id: string;
-  source: string;
-  settings: {
-    agentCount: number;
-    maxStepsPerAgent: number;
-    durationSec: number;
-    mode: "requeue" | "random";
-    persistentMemory: boolean;
-  };
-  participants: Participant[];
-  agentResults: AgentResult[];
-  snapshot: Snapshot;
-  activity: Activity[];
-  report: string | null;
-  totals: Totals;
-  createdAt: string;
-};
+// Wire shapes shared with the server. The single source of truth lives in
+// /shared/contracts.ts; this module just re-exports so existing client
+// imports keep working.
+export type {
+  Post,
+  CommentNode,
+  Snapshot,
+  Participant,
+  AgentResult,
+  Totals,
+  SimulationResult,
+  RunRecord,
+  RunSettings,
+  SimulationMode,
+  VoteResult,
+  ActivityEvent as Activity,
+  ActivityEvent,
+  RunStreamEvent,
+  RunStreamEventMap,
+  RunStreamEventName,
+} from "../../shared/contracts";

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -10,7 +10,8 @@
     "skipLibCheck": true,
     "resolveJsonModule": true,
     "types": ["vite/client"],
+    "rootDir": "..",
     "noEmit": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "../shared/**/*"]
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,12 +1,18 @@
 import "dotenv/config";
 import express from "express";
+import type { Response } from "express";
 import cors from "cors";
 import { z } from "zod";
 import { loadProfiles } from "./profiles.js";
 import { runPipeline } from "./runPipeline.js";
 import prisma from "./resources/prisma.js";
 import cryptr from "./resources/cryptr.js";
-import { encryptedKeySchema } from "./encryptedKey.js";
+import { runRequestSchema } from "./runRequestSchema.js";
+import type {
+  RunRecord,
+  RunStreamEventMap,
+  RunStreamEventName,
+} from "../../shared/contracts.js";
 import {
   searchOpenRouterModels,
   trimModelForClient,
@@ -27,17 +33,6 @@ if (!process.env.OPENROUTER_API_KEY) {
   throw new Error("OPENROUTER_API_KEY environment variable is required");
 }
 
-const requestSchema = z.object({
-  source: z.string().min(1).max(20000),
-  encryptedKey: encryptedKeySchema,
-  agentCount: z.number().int().min(1).max(50).default(10),
-  maxStepsPerAgent: z.number().int().min(1).max(40).default(12),
-  durationSec: z.number().int().min(10).max(300).default(30),
-  mode: z.enum(["requeue", "random"]).default("requeue"),
-  persistentMemory: z.boolean().default(true),
-  modelId: z.string().min(1).max(200).optional(),
-});
-
 const encryptKeySchema = z.object({
   key: z.string().min(1).max(256),
 });
@@ -57,6 +52,18 @@ function resolveApiKey(encryptedKey: string): { apiKey: string; mode: "user" | "
     return { apiKey: process.env.OPENROUTER_API_KEY!, mode: "admin" };
   }
   return { apiKey: plaintext, mode: "user" };
+}
+
+// Typed wrapper around `res.write` so adding an event in the contract is a
+// compile error here until the emit site is updated.
+function makeSseSender(res: Response) {
+  return <K extends RunStreamEventName>(
+    name: K,
+    data: RunStreamEventMap[K]
+  ) => {
+    res.write(`event: ${name}\n`);
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+  };
 }
 
 async function validateOpenRouterKey(apiKey: string): Promise<boolean> {
@@ -132,7 +139,7 @@ app.get("/api/profiles", (_req, res) => {
 });
 
 app.post("/api/run", async (req, res) => {
-  const parsed = requestSchema.safeParse(req.body);
+  const parsed = runRequestSchema.safeParse(req.body);
   if (!parsed.success) {
     return res
       .status(400)
@@ -168,7 +175,7 @@ app.post("/api/run", async (req, res) => {
 // Streaming variant: emit each ActivityEvent + final result as a Server-Sent
 // Events stream so the client can render comments arriving live.
 app.post("/api/run-stream", async (req, res) => {
-  const parsed = requestSchema.safeParse(req.body);
+  const parsed = runRequestSchema.safeParse(req.body);
   if (!parsed.success) {
     return res
       .status(400)
@@ -189,10 +196,7 @@ app.post("/api/run-stream", async (req, res) => {
   res.setHeader("Connection", "keep-alive");
   res.flushHeaders?.();
 
-  const send = (event: string, data: unknown) => {
-    res.write(`event: ${event}\n`);
-    res.write(`data: ${JSON.stringify(data)}\n\n`);
-  };
+  const send = makeSseSender(res);
 
   send("start", { agentCount: request.agentCount });
   try {
@@ -224,14 +228,14 @@ app.get("/api/runs/:id", async (req, res) => {
   try {
     const row = await prisma.run.findUnique({ where: { id } });
     if (!row) return res.status(404).json({ error: "run not found" });
-    res.json({
+    const record: RunRecord = {
       id: row.id,
       source: row.source,
       settings: {
         agentCount: row.agentCount,
         maxStepsPerAgent: row.maxStepsPerAgent,
         durationSec: row.durationSec,
-        mode: row.mode,
+        mode: row.mode as RunRecord["settings"]["mode"],
         persistentMemory: row.persistentMemory,
       },
       participants: JSON.parse(row.participants),
@@ -241,7 +245,8 @@ app.get("/api/runs/:id", async (req, res) => {
       report: row.report,
       totals: JSON.parse(row.totals),
       createdAt: row.createdAt.toISOString(),
-    });
+    };
+    res.json(record);
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     console.error(`GET /api/runs/${id} failed:`, msg);

--- a/server/src/runPipeline.ts
+++ b/server/src/runPipeline.ts
@@ -7,7 +7,7 @@ import {
   type SimulationResult,
 } from "./runSimulation.js";
 import { generateReport, type ReportResult } from "./report.js";
-import type { ActivityEvent } from "./tools.js";
+import type { ActivityEvent, SimulationMode } from "../../shared/contracts.js";
 import type { Profile } from "./profiles.js";
 import prisma from "./resources/prisma.js";
 
@@ -16,7 +16,7 @@ export interface PipelineRequest {
   agentCount: number;
   maxStepsPerAgent: number;
   durationSec: number;
-  mode: "requeue" | "random";
+  mode: SimulationMode;
   persistentMemory: boolean;
   modelId?: string;
 }

--- a/server/src/runRequestSchema.ts
+++ b/server/src/runRequestSchema.ts
@@ -13,3 +13,16 @@ export const encryptedKeySchema = z
   .max(ENCRYPTED_KEY_MAX)
   .regex(/^[0-9a-f]+$/, "must be lowercase hex")
   .refine((s) => s.length % 2 === 0, "must be even-length hex");
+
+export const runRequestSchema = z.object({
+  source: z.string().min(1).max(20000),
+  encryptedKey: encryptedKeySchema,
+  agentCount: z.number().int().min(1).max(50).default(10),
+  maxStepsPerAgent: z.number().int().min(1).max(40).default(12),
+  durationSec: z.number().int().min(10).max(300).default(30),
+  mode: z.enum(["requeue", "random"]).default("requeue"),
+  persistentMemory: z.boolean().default(true),
+  modelId: z.string().min(1).max(200).optional(),
+});
+
+export type RunRequest = z.infer<typeof runRequestSchema>;

--- a/server/src/runSimulation.ts
+++ b/server/src/runSimulation.ts
@@ -4,7 +4,7 @@ import { Frontpage, type FrontpageSnapshot } from "./frontpage.js";
 import { runAgent, type AgentRunResult } from "./agent.js";
 
 export type PublicAgentResult = Omit<AgentRunResult, "messages">;
-import type { ActivityEvent } from "./tools.js";
+import type { ActivityEvent, SimulationMode } from "../../shared/contracts.js";
 import { sampleProfiles, type Profile } from "./profiles.js";
 
 export const DEFAULT_MODEL_ID = "google/gemini-3.1-flash-lite-preview";
@@ -14,7 +14,7 @@ export const DEFAULT_MODEL_ID = "google/gemini-3.1-flash-lite-preview";
 // people drop in, post, come back later when something new is on top.
 // 'random' picks a participant at random for every open slot — chaotic
 // and uneven; loud users may post 5x while others post once.
-export type SimulationMode = "requeue" | "random";
+export type { SimulationMode };
 
 export interface SimulationOptions {
   source: string;

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -6,6 +6,9 @@ import {
   UnknownEntityError,
   type SortMode,
 } from "./frontpage.js";
+import type { ActivityEvent } from "../../shared/contracts.js";
+
+export type { ActivityEvent } from "../../shared/contracts.js";
 
 export interface ToolContext {
   fp: Frontpage;
@@ -14,16 +17,6 @@ export interface ToolContext {
   // orchestrator can stream progress to the client / log activity.
   onActivity?: (event: ActivityEvent) => void;
 }
-
-export type ActivityEvent =
-  | { kind: "post-created"; postId: string; username: string; title: string }
-  | { kind: "comment-created"; commentId: string; postId: string; parentId: string; username: string; body: string }
-  | { kind: "vote"; entityId: string; username: string; type: "up" | "down"; result: "set" | "cleared" | "switched" }
-  | { kind: "tool-error"; tool: string; username: string; error: string }
-  // Synthesized milestone markers — not emitted by tools but pushed by the
-  // run handler so the saved activity log replays the same phase banners
-  // the user saw live.
-  | { kind: "phase"; label: string; tone: "info" | "success" | "start" | "error" };
 
 const sortSchema = z
   .enum(["top", "new", "controversial"])

--- a/server/tests/encryptedKey.test.ts
+++ b/server/tests/encryptedKey.test.ts
@@ -3,7 +3,7 @@ import {
   encryptedKeySchema,
   ENCRYPTED_KEY_MIN,
   ENCRYPTED_KEY_MAX,
-} from "../src/encryptedKey.js";
+} from "../src/runRequestSchema.js";
 
 const hex = (n: number) => "a".repeat(n);
 

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -9,8 +9,9 @@
     "resolveJsonModule": true,
     "allowImportingTsExtensions": false,
     "noEmit": true,
+    "rootDir": "..",
     "outDir": "dist",
     "types": ["node"]
   },
-  "include": ["src/**/*", "tests/**/*"]
+  "include": ["src/**/*", "tests/**/*", "../shared/**/*"]
 }

--- a/shared/contracts.ts
+++ b/shared/contracts.ts
@@ -1,0 +1,163 @@
+// Single source of truth for everything that crosses the wire between the
+// GlassHive server and client: response shapes, the activity event union,
+// and the run-stream event map. No runtime deps so importing this module
+// from the client doesn't pull zod or anything else into the browser bundle.
+
+// ====== Frontpage primitives ======
+
+export type Post = {
+  id: string;
+  authorUsername: string;
+  title: string;
+  body: string;
+  createdAt: number;
+};
+
+export type CommentNode = {
+  id: string;
+  authorUsername: string;
+  body: string;
+  createdAt: number;
+  parentId: string;
+  karma: number;
+  upvotes: number;
+  downvotes: number;
+  replies: CommentNode[];
+};
+
+export type Snapshot = {
+  posts: Array<{
+    post: Post;
+    karma: number;
+    upvotes: number;
+    downvotes: number;
+    comments: CommentNode[];
+  }>;
+  exportedAt: number;
+};
+
+// ====== Activity events ======
+
+export type VoteResult = "set" | "cleared" | "switched";
+
+export type ActivityEvent =
+  | { kind: "post-created"; postId: string; username: string; title: string }
+  | {
+      kind: "comment-created";
+      commentId: string;
+      postId: string;
+      parentId: string;
+      username: string;
+      body: string;
+    }
+  | {
+      kind: "vote";
+      entityId: string;
+      username: string;
+      type: "up" | "down";
+      result: VoteResult;
+    }
+  | { kind: "tool-error"; tool: string; username: string; error: string }
+  | { kind: "phase"; label: string; tone: "info" | "success" | "start" | "error" };
+
+// ====== Simulation result shapes ======
+
+export type Participant = {
+  username: string;
+  name: string;
+  occupation: string;
+  location: string;
+};
+
+export type AgentResult = {
+  username: string;
+  steps: number;
+  finishReason: string | null;
+  costUsd: number;
+  tokens: { input: number; output: number };
+  errored: boolean;
+  error?: string;
+};
+
+export type Totals = {
+  costUsd: number;
+  inputTokens: number;
+  outputTokens: number;
+  posts: number;
+  comments: number;
+  elapsedMs: number;
+};
+
+export type SimulationResult = {
+  id?: string;
+  source: string;
+  participants: Participant[];
+  agentResults: AgentResult[];
+  snapshot: Snapshot;
+  report?: string | null;
+  totals: Totals;
+};
+
+// ====== Run record (GET /api/runs/:id) ======
+
+export type SimulationMode = "requeue" | "random";
+
+export type RunSettings = {
+  agentCount: number;
+  maxStepsPerAgent: number;
+  durationSec: number;
+  mode: SimulationMode;
+  persistentMemory: boolean;
+};
+
+export type RunRecord = {
+  id: string;
+  source: string;
+  settings: RunSettings;
+  participants: Participant[];
+  agentResults: AgentResult[];
+  snapshot: Snapshot;
+  activity: ActivityEvent[];
+  report: string | null;
+  totals: Totals;
+  createdAt: string;
+};
+
+// ====== Run-stream events ======
+
+// One event-name → payload map that both the server emitter and the client
+// parser switch over. Adding a new event is a compile error on either side
+// until both ends are updated, which is the whole point of the contract.
+export type RunStreamEventMap = {
+  start: { agentCount: number };
+  activity: ActivityEvent;
+  "agent-done": AgentResult;
+  "simulation-complete": { posts: number; comments: number };
+  "report-start": Record<string, never>;
+  "report-done": { markdown: string | null; error?: string };
+  saved: { id: string };
+  done: SimulationResult;
+  error: { error: string };
+};
+
+export type RunStreamEventName = keyof RunStreamEventMap;
+
+export type RunStreamEvent = {
+  [K in RunStreamEventName]: { name: K; data: RunStreamEventMap[K] };
+}[RunStreamEventName];
+
+export const RUN_STREAM_EVENT_NAMES = [
+  "start",
+  "activity",
+  "agent-done",
+  "simulation-complete",
+  "report-start",
+  "report-done",
+  "saved",
+  "done",
+  "error",
+] as const satisfies ReadonlyArray<RunStreamEventName>;
+
+export function isRunStreamEventName(name: string): name is RunStreamEventName {
+  return (RUN_STREAM_EVENT_NAMES as ReadonlyArray<string>).includes(name);
+}


### PR DESCRIPTION
Closes #7

## Summary

- New top-level `shared/contracts.ts` is the single source of truth for everything that crosses the wire: `Post`, `CommentNode`, `Snapshot`, `Participant`, `AgentResult`, `Totals`, `SimulationResult`, `RunRecord`, `RunSettings`, `SimulationMode`, `ActivityEvent` (with `VoteResult = "set" | "cleared" | "switched"`), and a `RunStreamEventMap` pinning each event name to its payload type. Pure TypeScript with no runtime deps, so the client doesn't pull zod into its bundle.
- Server's SSE `send()` is now `<K extends RunStreamEventName>(name: K, data: RunStreamEventMap[K]) => void` — adding or renaming a stream event without updating both ends is a compile error.
- Client parser uses `isRunStreamEventName()` from the contract to filter unknown event names, and `useRunSimulation`'s switch is exhaustively checked against the union. `client/src/types.ts` re-exports from shared (with `ActivityEvent` aliased as `Activity`) so existing component imports are untouched.
- The zod request schema moved to `server/src/runRequestSchema.ts` (renamed from `encryptedKey.ts`). Putting it in `shared/` was tempting, but Node module resolution walking up from `/shared/` doesn't reach `/server/node_modules/zod` — and only the server validates the body, so it lives next to its consumer.

## Acceptance criteria

- [x] One source of truth for run API and stream event payload types (`shared/contracts.ts`).
- [x] Client no longer manually weakens server unions — `Activity.vote.result` is now the narrow `"set" | "cleared" | "switched"` union.
- [x] Stream parser/dispatcher is exhaustively typed by event name (`RunStreamEvent` discriminated union).
- [x] Both packages compile under strict TypeScript (`server: tsc --noEmit`, `client: tsc -b && vite build`).

## Test plan

- [ ] `cd server && npm test` — 32 tests pass (frontpage + encryptedKey schemas).
- [ ] `cd client && npm run build` — vite build succeeds, bundle size unchanged-ish (145.72 kB → 145.72 kB; zod did not leak in).
- [ ] `cd server && npm run dev` — server boots, `/api/health` responds.
- [ ] End-to-end: launch both dev servers, run a simulation through the UI, confirm activity events render and `/v/:id` loads after save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)