### PR TITLE
Hygiene: fix README drift, add Prettier baseline, trim Frontpage surface

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+node_modules
+dist
+build
+coverage
+*.db
+*.db-journal
+prisma/migrations
+profiles
+assets

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "es5",
+  "tabWidth": 2
+}

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@
 - **Client:** SolidJS + Vite + Tailwind v4 (port 3810)
 - **Server:** Express 5 + tsx + Zod 4 (port 3811)
 - **AI:** Vercel AI SDK v6 + OpenRouter (`@openrouter/ai-sdk-provider`)
-- **Tests:** Vitest (server-side, against the `Frontpage` class)
-- **State:** In-memory only. No database. Each run lives entirely inside one `runSimulation()` call.
+- **Tests:** Vitest — server-side against the `Frontpage` class; client-side under jsdom for components.
+- **Persistence:** Prisma + SQLite. One `Run` row per finished simulation (source, settings, activity log, agent results, snapshot, report markdown, totals). In-flight runs live in memory; only completed runs are saved. The public `/v/:id` page reads back from this row.
 
 ## Quickstart
 
@@ -77,7 +77,12 @@ Open http://localhost:3810, paste source material, tune the sliders, and hit **O
 | Var | Required | Default |
 |---|---|---|
 | `OPENROUTER_API_KEY` | yes | — |
+| `MASTER_ENCRYPTION_KEY` | yes (≥16 chars) | — |
+| `ADMIN_PASSWORD` | yes | — |
+| `DATABASE_URL` | yes | `file:./dev.db` |
 | `PORT` | no | `3811` |
+
+The first run also needs `npm run db:push` inside `server/` to create the SQLite schema.
 
 ## How a Run Works
 
@@ -94,8 +99,9 @@ Open http://localhost:3810, paste source material, tune the sliders, and hit **O
 |---|---|---|
 | GET | `/api/health` | Liveness + profile count |
 | GET | `/api/profiles` | List all 250+ personas |
-| POST | `/api/run` | Run a simulation synchronously, return the full result |
-| POST | `/api/run-stream` | Run a simulation as Server-Sent Events |
+| POST | `/api/run` | Run a simulation synchronously, persist it, return the full result + new `id` |
+| POST | `/api/run-stream` | Run a simulation as Server-Sent Events; emits `saved { id }` once persisted |
+| GET | `/api/runs/:id` | Fetch a saved run by uuid (powers the public `/v/:id` page) |
 
 Request body (Zod-validated):
 
@@ -110,37 +116,66 @@ Request body (Zod-validated):
 }
 ```
 
-SSE event types: `start`, `activity`, `agent-done`, `done`, `error`.
+SSE event types: `start`, `activity`, `agent-done`, `simulation-complete`, `report-start`, `report-done`, `saved`, `done`, `error`.
 
 ## Tests
 
 ```bash
-cd server
-npm test           # vitest run
-npm run test:watch
+cd server && npm test           # vitest run — Frontpage logic, no DOM
+cd server && npm run test:watch
+
+cd client && npm test           # vitest + jsdom — component tests
+cd client && npm run test:watch
 ```
 
-Tests cover the `Frontpage` class — voting, threading, sort modes (`top` / `new` / `controversial`), and snapshot. No AI / no network.
+Server tests cover the `Frontpage` class — voting, threading, sort modes (`top` / `new` / `controversial`), and snapshot. No AI / no network.
+
+## Formatting
+
+The repo ships a Prettier baseline (`.prettierrc.json`) and per-package scripts:
+
+```bash
+cd client && npm run format        # client/src
+cd server && npm run format        # server/src + tests
+```
+
+`npm run format:check` returns non-zero if anything is unformatted. There is intentionally no ESLint config — typecheck (`tsc -b`) is the source of truth for correctness, and Prettier handles style.
 
 ## Project Layout
 
 ```
 assets/                  README banner + screenshots
+shared/                  Cross-package contracts
+  contracts.ts           RunRecord + RunStreamEventMap shared by client and server
+
 client/                  SolidJS + Vite UI
   public/favicon.svg
   src/
-    App.tsx              The whole UI
-    app.css              Tailwind v4 entry
-    index.tsx
+    index.tsx            Router setup (/ → Home, /v/:id → View)
+    app.css              Tailwind v4 entry + .report-md @apply rules
+    types.ts             Shared client-side types (Activity, RunRecord, etc.)
+    components/          Logo, CommentTree, ActivityFeed, ActivityLine,
+                         Report, Thread, KeyGate, ModelPicker
+    hooks/useRunSimulation.ts   Live run state + countdown + SSE wiring
+    lib/                 format, runStream (typed SSE parser), keyStore, modelStore
+    pages/Home.tsx       Form + live feed; navigates to /v/:id when saved
+    pages/View.tsx       Read-only saved view (public, no auth)
+
 server/                  Express + tsx
-  profiles/              250+ unique persona markdown files (modeled to mirror a real sample of society)
+  prisma/schema.prisma   SQLite — one Run row per finished simulation
+  profiles/              250+ unique persona markdown files
   src/
-    index.ts             HTTP routes
+    index.ts             HTTP routes (/api/run, /api/run-stream, /api/runs/:id, …)
     profiles.ts          loadProfiles() + deriveUsername()
     frontpage.ts         Pure thread mechanics (posts, comments, votes, sort)
     tools.ts             Six Vercel AI SDK tools per agent
     agent.ts             runAgent() — one session
     runSimulation.ts     The orchestrator
+    runPipeline.ts       Simulation + report + persist, shared by both routes
+    runRequestSchema.ts  Zod schema for the run request body
+    report.ts            generateReport() — one no-tools call to summarize
+    openrouter-models.ts /api/models search-and-trim
+    resources/           prisma + cryptr singletons
   tests/frontpage.test.ts
 ```
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -20,6 +20,7 @@
         "@tailwindcss/vite": "^4.1.11",
         "@testing-library/jest-dom": "^6.9.1",
         "jsdom": "^29.1.0",
+        "prettier": "^3.4.2",
         "tailwindcss": "^4.1.11",
         "typescript": "^5.4.5",
         "vite": "^7.2.4",
@@ -3043,6 +3044,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/client/package.json
+++ b/client/package.json
@@ -7,7 +7,9 @@
     "build": "tsc -b && vite build",
     "preview": "vite preview",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "format": "prettier --write \"src/**/*.{ts,tsx,css,json}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,css,json}\""
   },
   "dependencies": {
     "@solidjs/router": "^0.16.1",
@@ -22,6 +24,7 @@
     "@tailwindcss/vite": "^4.1.11",
     "@testing-library/jest-dom": "^6.9.1",
     "jsdom": "^29.1.0",
+    "prettier": "^3.4.2",
     "tailwindcss": "^4.1.11",
     "typescript": "^5.4.5",
     "vite": "^7.2.4",

--- a/client/src/app.css
+++ b/client/src/app.css
@@ -1,11 +1,20 @@
 @import "tailwindcss";
 
-html, body, #root {
+html,
+body,
+#root {
   height: 100%;
   background: #0b0b0f;
   color: #f3f3f5;
-  font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto,
-    "Helvetica Neue", Arial, sans-serif;
+  font-family:
+    ui-sans-serif,
+    system-ui,
+    -apple-system,
+    "Segoe UI",
+    Roboto,
+    "Helvetica Neue",
+    Arial,
+    sans-serif;
 }
 
 body {
@@ -74,22 +83,60 @@ input[type="range"]:disabled::-moz-range-thumb {
   cursor: not-allowed;
 }
 
-.report-md > *:first-child { margin-top: 0; }
-.report-md > *:last-child { margin-bottom: 0; }
-.report-md h1 { @apply text-2xl font-bold text-neutral-100 mt-6 mb-3; }
-.report-md h2 { @apply text-xl font-bold text-neutral-100 mt-5 mb-2; }
-.report-md h3 { @apply text-lg font-semibold text-neutral-200 mt-4 mb-2; }
-.report-md h4 { @apply text-base font-semibold text-neutral-200 mt-3 mb-2; }
-.report-md p  { @apply text-sm leading-relaxed text-neutral-300 my-3; }
-.report-md ul { @apply list-disc pl-6 my-3 text-sm text-neutral-300; }
-.report-md ol { @apply list-decimal pl-6 my-3 text-sm text-neutral-300; }
-.report-md li { @apply my-1; }
-.report-md li > p { @apply my-0; }
-.report-md blockquote { @apply border-l-2 border-neutral-700 pl-3 italic text-neutral-400 my-3; }
-.report-md code { @apply rounded bg-neutral-800 px-1 py-0.5 font-mono text-xs text-neutral-200; }
-.report-md pre { @apply rounded bg-neutral-950 p-3 my-3 overflow-x-auto; }
-.report-md pre code { @apply bg-transparent p-0; }
-.report-md a  { @apply text-orange-400 underline hover:text-orange-300; }
-.report-md strong { @apply font-semibold text-neutral-100; }
-.report-md em { @apply italic; }
-.report-md hr { @apply my-4 border-neutral-800; }
+.report-md > *:first-child {
+  margin-top: 0;
+}
+.report-md > *:last-child {
+  margin-bottom: 0;
+}
+.report-md h1 {
+  @apply text-2xl font-bold text-neutral-100 mt-6 mb-3;
+}
+.report-md h2 {
+  @apply text-xl font-bold text-neutral-100 mt-5 mb-2;
+}
+.report-md h3 {
+  @apply text-lg font-semibold text-neutral-200 mt-4 mb-2;
+}
+.report-md h4 {
+  @apply text-base font-semibold text-neutral-200 mt-3 mb-2;
+}
+.report-md p {
+  @apply text-sm leading-relaxed text-neutral-300 my-3;
+}
+.report-md ul {
+  @apply list-disc pl-6 my-3 text-sm text-neutral-300;
+}
+.report-md ol {
+  @apply list-decimal pl-6 my-3 text-sm text-neutral-300;
+}
+.report-md li {
+  @apply my-1;
+}
+.report-md li > p {
+  @apply my-0;
+}
+.report-md blockquote {
+  @apply border-l-2 border-neutral-700 pl-3 italic text-neutral-400 my-3;
+}
+.report-md code {
+  @apply rounded bg-neutral-800 px-1 py-0.5 font-mono text-xs text-neutral-200;
+}
+.report-md pre {
+  @apply rounded bg-neutral-950 p-3 my-3 overflow-x-auto;
+}
+.report-md pre code {
+  @apply bg-transparent p-0;
+}
+.report-md a {
+  @apply text-orange-400 underline hover:text-orange-300;
+}
+.report-md strong {
+  @apply font-semibold text-neutral-100;
+}
+.report-md em {
+  @apply italic;
+}
+.report-md hr {
+  @apply my-4 border-neutral-800;
+}

--- a/client/src/components/ActivityFeed.tsx
+++ b/client/src/components/ActivityFeed.tsx
@@ -99,9 +99,7 @@ export default function ActivityFeed(props: {
             style={{ "scroll-behavior": "smooth" }}
           >
             <div class="mt-auto">
-              <For each={props.activity.slice(-80)}>
-                {(e) => <ActivityLine event={e} />}
-              </For>
+              <For each={props.activity.slice(-80)}>{(e) => <ActivityLine event={e} />}</For>
             </div>
           </div>
         </section>

--- a/client/src/components/KeyGate.tsx
+++ b/client/src/components/KeyGate.tsx
@@ -44,9 +44,8 @@ export default function KeyGate(props: { onSaved: (blob: StoredKey) => void }) {
       </label>
       <p class="mt-1 text-xs text-neutral-500">
         GlassHive uses your own OpenRouter credit. Paste a key (
-        <code class="text-neutral-400">sk-or-v1-…</code>) or the host admin
-        password. The key is encrypted on the server and stored only in this
-        browser.
+        <code class="text-neutral-400">sk-or-v1-…</code>) or the host admin password. The key is
+        encrypted on the server and stored only in this browser.
       </p>
       <input
         type="password"

--- a/client/src/components/ModelPicker.tsx
+++ b/client/src/components/ModelPicker.tsx
@@ -1,10 +1,4 @@
-import {
-  createSignal,
-  createEffect,
-  onCleanup,
-  For,
-  Show,
-} from "solid-js";
+import { createSignal, createEffect, onCleanup, For, Show } from "solid-js";
 import {
   TbOutlineCpu,
   TbOutlineChevronDown,
@@ -71,11 +65,7 @@ export default function ModelPicker(props: Props) {
   let searchDebounce: ReturnType<typeof setTimeout> | null = null;
   let loadedOnce = false;
 
-  async function fetchPage(args: {
-    offset: number;
-    search: string;
-    append: boolean;
-  }) {
+  async function fetchPage(args: { offset: number; search: string; append: boolean }) {
     if (args.append) setIsLoadingMore(true);
     else setIsLoading(true);
     setError("");
@@ -137,15 +127,9 @@ export default function ModelPicker(props: Props) {
 
   const onScroll = (e: Event) => {
     const target = e.currentTarget as HTMLDivElement;
-    const scrollBottom =
-      target.scrollHeight - target.scrollTop - target.clientHeight;
+    const scrollBottom = target.scrollHeight - target.scrollTop - target.clientHeight;
     const offset = nextOffset();
-    if (
-      scrollBottom < 200 &&
-      hasMore() &&
-      !isLoadingMore() &&
-      offset != null
-    ) {
+    if (scrollBottom < 200 && hasMore() && !isLoadingMore() && offset != null) {
       void fetchPage({ offset, search: search(), append: true });
     }
   };
@@ -180,9 +164,7 @@ export default function ModelPicker(props: Props) {
         >
           <div class="flex max-h-[80vh] w-full max-w-3xl flex-col overflow-hidden rounded-2xl border border-neutral-800 bg-neutral-950 shadow-2xl">
             <div class="flex items-center justify-between border-b border-neutral-800 px-5 py-4">
-              <h2 class="text-base font-semibold text-neutral-100">
-                Pick a model
-              </h2>
+              <h2 class="text-base font-semibold text-neutral-100">Pick a model</h2>
               <button
                 type="button"
                 onClick={() => setOpen(false)}
@@ -221,10 +203,7 @@ export default function ModelPicker(props: Props) {
                 when={!isLoading()}
                 fallback={
                   <div class="flex items-center justify-center py-12">
-                    <TbOutlineLoader2
-                      size={24}
-                      class="animate-spin text-orange-500"
-                    />
+                    <TbOutlineLoader2 size={24} class="animate-spin text-orange-500" />
                   </div>
                 }
               >
@@ -290,9 +269,7 @@ export default function ModelPicker(props: Props) {
                               <span> /M in</span>
                               <span class="mx-1 text-neutral-700">·</span>
                               <span class="font-mono">
-                                {formatPricePerMillion(
-                                  model.pricing.completion,
-                                )}
+                                {formatPricePerMillion(model.pricing.completion)}
                               </span>
                               <span> /M out</span>
                             </div>
@@ -319,14 +296,8 @@ export default function ModelPicker(props: Props) {
                     </div>
                   </Show>
 
-                  <Show
-                    when={
-                      !hasMore() && !isLoadingMore() && models().length > 0
-                    }
-                  >
-                    <div class="py-4 text-center text-[11px] text-neutral-600">
-                      End of list
-                    </div>
+                  <Show when={!hasMore() && !isLoadingMore() && models().length > 0}>
+                    <div class="py-4 text-center text-[11px] text-neutral-600">End of list</div>
                   </Show>
                 </Show>
               </Show>

--- a/client/src/components/Thread.tsx
+++ b/client/src/components/Thread.tsx
@@ -25,8 +25,7 @@ export default function Thread(props: { result: SimulationResult }) {
         when={props.result.snapshot.posts.length > 0}
         fallback={
           <p class="rounded-xl border border-amber-900/60 bg-amber-950/30 p-4 text-sm text-amber-300">
-            The room logged on but no one posted. Try giving the agents more
-            steps or duration.
+            The room logged on but no one posted. Try giving the agents more steps or duration.
           </p>
         }
       >
@@ -39,26 +38,20 @@ export default function Thread(props: { result: SimulationResult }) {
                     <span class={`text-2xl font-bold ${karmaColor(p.karma)}`}>
                       {p.karma >= 0 ? "▲" : "▼"}
                     </span>
-                    <span class={`font-mono text-lg ${karmaColor(p.karma)}`}>
-                      {p.karma}
-                    </span>
+                    <span class={`font-mono text-lg ${karmaColor(p.karma)}`}>{p.karma}</span>
                   </div>
                   <div class="flex-1">
                     <div class="text-xs text-neutral-500">
-                      posted by{" "}
-                      <span class="text-neutral-300">u/{p.post.authorUsername}</span>
+                      posted by <span class="text-neutral-300">u/{p.post.authorUsername}</span>
                     </div>
-                    <h3 class="mt-1 text-xl font-bold text-neutral-100">
-                      {p.post.title}
-                    </h3>
+                    <h3 class="mt-1 text-xl font-bold text-neutral-100">{p.post.title}</h3>
                     <Show when={p.post.body.trim().length > 0}>
                       <p class="mt-2 whitespace-pre-wrap text-sm leading-relaxed text-neutral-300">
                         {p.post.body}
                       </p>
                     </Show>
                     <div class="mt-2 text-xs text-neutral-500">
-                      {p.upvotes}↑ {p.downvotes}↓ ·{" "}
-                      {countAllComments(p.comments)} comments
+                      {p.upvotes}↑ {p.downvotes}↓ · {countAllComments(p.comments)} comments
                     </div>
                   </div>
                 </header>

--- a/client/src/hooks/useRunSimulation.ts
+++ b/client/src/hooks/useRunSimulation.ts
@@ -63,17 +63,11 @@ export function useRunSimulation(opts: UseRunSimulationOptions = {}) {
         ]);
         return;
       case "report-start":
-        setActivity((arr) => [
-          ...arr,
-          { kind: "phase", label: "Writing report…", tone: "info" },
-        ]);
+        setActivity((arr) => [...arr, { kind: "phase", label: "Writing report…", tone: "info" }]);
         return;
       case "report-done":
         if (event.data.markdown) {
-          setActivity((arr) => [
-            ...arr,
-            { kind: "phase", label: "Report ready", tone: "success" },
-          ]);
+          setActivity((arr) => [...arr, { kind: "phase", label: "Report ready", tone: "success" }]);
         } else {
           setActivity((arr) => [
             ...arr,
@@ -98,9 +92,7 @@ export function useRunSimulation(opts: UseRunSimulationOptions = {}) {
   const run = async (input: RunStreamInput) => {
     setLoading(true);
     setError(null);
-    setActivity([
-      { kind: "phase", label: "Starting simulation…", tone: "start" },
-    ]);
+    setActivity([{ kind: "phase", label: "Starting simulation…", tone: "start" }]);
     setDoneAgents([]);
     setLogCollapsed(false);
     startTimer(input.durationSec);

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -15,5 +15,5 @@ render(
       <Route path="/v/:id" component={View} />
     </Router>
   ),
-  root,
+  root
 );

--- a/client/src/lib/runStream.ts
+++ b/client/src/lib/runStream.ts
@@ -50,9 +50,7 @@ function parseChunk(chunk: string): RunStreamEvent | null {
   return { name, data } as RunStreamEvent;
 }
 
-export async function* openRunStream(
-  input: RunStreamInput,
-): AsyncGenerator<RunStreamEvent> {
+export async function* openRunStream(input: RunStreamInput): AsyncGenerator<RunStreamEvent> {
   const res = await fetch("/api/run-stream", {
     method: "POST",
     headers: { "Content-Type": "application/json" },

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -38,9 +38,7 @@ export default function Home() {
   const [showAdvanced, setShowAdvanced] = createSignal(false);
 
   const [keyBlob, setKeyBlob] = createSignal<StoredKey | null>(getStoredKey());
-  const [modelId, setModelIdInternal] = createSignal<string | null>(
-    getStoredModel(),
-  );
+  const [modelId, setModelIdInternal] = createSignal<string | null>(getStoredModel());
 
   const setModelId = (id: string | null) => {
     setModelIdInternal(id);
@@ -52,19 +50,11 @@ export default function Home() {
     setKeyBlob(null);
   };
 
-  const {
-    loading,
-    error,
-    activity,
-    doneAgents,
-    logCollapsed,
-    setLogCollapsed,
-    remainingSec,
-    run,
-  } = useRunSimulation({
-    onSaved: (id) => navigate(`/v/${id}`),
-    onUnauthorized: resetKey,
-  });
+  const { loading, error, activity, doneAgents, logCollapsed, setLogCollapsed, remainingSec, run } =
+    useRunSimulation({
+      onSaved: (id) => navigate(`/v/${id}`),
+      onUnauthorized: resetKey,
+    });
 
   const submit = () => {
     const text = source().trim();
@@ -90,16 +80,12 @@ export default function Home() {
           <div>
             <Logo />
             <p class="mt-3 mb-2 text-sm text-neutral-400">
-              Drop in source material. Watch a roomful of AI agents argue about
-              it in a fake comment section.
+              Drop in source material. Watch a roomful of AI agents argue about it in a fake comment
+              section.
             </p>
           </div>
           <div class="flex items-center gap-2">
-            <ModelPicker
-              value={modelId()}
-              onChange={setModelId}
-              disabled={loading()}
-            />
+            <ModelPicker value={modelId()} onChange={setModelId} disabled={loading()} />
             <Show when={keyBlob()}>
               {(blob) => (
                 <button
@@ -110,9 +96,7 @@ export default function Home() {
                   title="Clear saved key and re-enter"
                 >
                   <TbOutlineKey size={14} class="text-neutral-500" />
-                  {blob().mode === "admin"
-                    ? "Host admin"
-                    : "Your OpenRouter key"}
+                  {blob().mode === "admin" ? "Host admin" : "Your OpenRouter key"}
                   <span class="text-neutral-600">· change</span>
                 </button>
               )}
@@ -178,9 +162,7 @@ export default function Home() {
                   size={16}
                   class="text-neutral-500 transition-transform"
                   style={{
-                    transform: showAdvanced()
-                      ? "rotate(90deg)"
-                      : "rotate(0deg)",
+                    transform: showAdvanced() ? "rotate(90deg)" : "rotate(0deg)",
                   }}
                 />
               </button>
@@ -195,9 +177,7 @@ export default function Home() {
                     disabled={loading()}
                     accent="text-orange-400"
                     unit="steps"
-                    icon={
-                      <TbOutlineHeartbeat size={16} class="text-neutral-500" />
-                    }
+                    icon={<TbOutlineHeartbeat size={16} class="text-neutral-500" />}
                   />
 
                   <div class="grid gap-5 md:grid-cols-2">
@@ -262,10 +242,7 @@ export default function Home() {
                 disabled={loading() || !source().trim() || !keyBlob()}
                 class="inline-flex items-center gap-2 rounded-lg bg-orange-500 px-6 py-3 text-sm font-semibold text-black shadow-lg shadow-orange-500/20 transition hover:bg-orange-400 disabled:cursor-not-allowed disabled:opacity-40"
               >
-                <Show
-                  when={loading()}
-                  fallback={<TbOutlineSparkles size={18} />}
-                >
+                <Show when={loading()} fallback={<TbOutlineSparkles size={18} />}>
                   <TbOutlineLoader2 size={18} class="animate-spin" />
                 </Show>
                 {loading() ? "The room is talking…" : "Generate"}
@@ -317,11 +294,7 @@ function ModeButton(props: {
   );
 }
 
-function Toggle(props: {
-  on: boolean;
-  disabled: boolean;
-  onToggle: () => void;
-}) {
+function Toggle(props: { on: boolean; disabled: boolean; onToggle: () => void }) {
   return (
     <button
       type="button"
@@ -370,9 +343,7 @@ function Slider(props: {
               <>
                 {props.value}
                 <Show when={props.unit}>
-                  <span class="ml-1 text-sm font-normal text-neutral-400">
-                    {props.unit}
-                  </span>
+                  <span class="ml-1 text-sm font-normal text-neutral-400">{props.unit}</span>
                 </Show>
               </>
             }
@@ -387,9 +358,7 @@ function Slider(props: {
         max={props.max}
         step={props.step ?? 1}
         value={props.value}
-        onInput={(e) =>
-          props.onChange(Number.parseInt(e.currentTarget.value, 10))
-        }
+        onInput={(e) => props.onChange(Number.parseInt(e.currentTarget.value, 10))}
         disabled={props.disabled}
         class="mt-2 w-full accent-orange-500"
       />

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -21,6 +21,7 @@
         "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/node": "^22.15.0",
+        "prettier": "^3.4.2",
         "prisma": "^6.19.3",
         "tsx": "^4.7.3",
         "typescript": "^5.4.5",
@@ -2382,6 +2383,22 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+      "integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/prisma": {

--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,9 @@
     "db:push": "prisma db push",
     "db:studio": "prisma studio",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\""
   },
   "dependencies": {
     "@openrouter/ai-sdk-provider": "2.3.3",
@@ -23,6 +25,7 @@
     "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/node": "^22.15.0",
+    "prettier": "^3.4.2",
     "prisma": "^6.19.3",
     "tsx": "^4.7.3",
     "typescript": "^5.4.5",

--- a/server/src/agent.ts
+++ b/server/src/agent.ts
@@ -1,9 +1,4 @@
-import {
-  generateText,
-  stepCountIs,
-  type LanguageModel,
-  type ModelMessage,
-} from "ai";
+import { generateText, stepCountIs, type LanguageModel, type ModelMessage } from "ai";
 import type { Profile } from "./profiles.js";
 import { buildTools, type ActivityEvent } from "./tools.js";
 import type { Frontpage } from "./frontpage.js";
@@ -80,9 +75,7 @@ Now go. Browse, read, vote, reply, and post like ${profile.name} would. Stay in 
 }
 
 function extractCost(providerMetadata: unknown): number {
-  const pm = providerMetadata as
-    | { openrouter?: { usage?: { cost?: number } } }
-    | undefined;
+  const pm = providerMetadata as { openrouter?: { usage?: { cost?: number } } } | undefined;
   const cost = pm?.openrouter?.usage?.cost;
   return typeof cost === "number" ? cost : 0;
 }
@@ -93,16 +86,7 @@ const FIRST_VISIT_USER = (name: string) =>
 const RETURN_VISIT_USER = `You're back on the forum. Time has passed; there may be new posts and replies (including replies to YOUR comments). Pull the latest state with get_posts and/or get_post, react to anything new — vote, reply, maybe start a fresh post if the thread has shifted. Stay in character. Don't repeat what you already said earlier. Don't ask me anything; just start using the tools.`;
 
 export async function runAgent(opts: AgentRunOptions): Promise<AgentRunResult> {
-  const {
-    profile,
-    source,
-    fp,
-    model,
-    maxSteps,
-    deadline,
-    onActivity,
-    priorMessages,
-  } = opts;
+  const { profile, source, fp, model, maxSteps, deadline, onActivity, priorMessages } = opts;
   if (Date.now() >= deadline) {
     return {
       username: profile.username,
@@ -127,22 +111,18 @@ export async function runAgent(opts: AgentRunOptions): Promise<AgentRunResult> {
         ];
 
   try {
-    const { response, totalUsage, finishReason, providerMetadata, steps } =
-      await generateText({
-        model,
-        tools,
-        stopWhen: stepCountIs(maxSteps),
-        providerOptions: {
-          openrouter: { usage: { include: true } },
-        },
-        messages: inputMessages,
-      });
+    const { response, totalUsage, finishReason, providerMetadata, steps } = await generateText({
+      model,
+      tools,
+      stopWhen: stepCountIs(maxSteps),
+      providerOptions: {
+        openrouter: { usage: { include: true } },
+      },
+      messages: inputMessages,
+    });
 
     const costUsd = extractCost(providerMetadata);
-    const fullHistory: ModelMessage[] = [
-      ...inputMessages,
-      ...(response.messages ?? []),
-    ];
+    const fullHistory: ModelMessage[] = [...inputMessages, ...(response.messages ?? [])];
     return {
       username: profile.username,
       steps: steps.length,

--- a/server/src/frontpage.ts
+++ b/server/src/frontpage.ts
@@ -1,7 +1,5 @@
 import { randomUUID } from "node:crypto";
 
-export type EntityKind = "post" | "comment";
-
 export interface Post {
   id: string;
   kind: "post";
@@ -159,7 +157,7 @@ export class Frontpage {
     return { up, down, karma: up - down };
   }
 
-  countCommentsFor(postId: string): number {
+  private countCommentsFor(postId: string): number {
     let n = 0;
     for (const c of this.comments.values()) {
       if (c.postId === postId) n++;
@@ -198,35 +196,7 @@ export class Frontpage {
         commentCount: this.countCommentsFor(p.id),
       });
     }
-    return sortSummaries(all, sort).slice(0, limit);
-  }
-
-  // Flat list of comments under a post, sorted. Used when an agent wants
-  // a quick sortable view rather than the nested tree.
-  listComments(
-    postId: string,
-    opts: { sort?: SortMode; limit?: number } = {}
-  ): CommentNode[] {
-    if (!this.posts.has(postId)) throw new UnknownEntityError(postId);
-    const sort = opts.sort ?? "top";
-    const limit = opts.limit ?? 50;
-    const flat: CommentNode[] = [];
-    for (const c of this.comments.values()) {
-      if (c.postId !== postId) continue;
-      const v = this.voteCounts(c.id);
-      flat.push({
-        id: c.id,
-        authorUsername: c.authorUsername,
-        body: c.body,
-        createdAt: c.createdAt,
-        parentId: c.parentId,
-        karma: v.karma,
-        upvotes: v.up,
-        downvotes: v.down,
-        replies: [],
-      });
-    }
-    return sortNodes(flat, sort).slice(0, limit);
+    return sortByMode(all, sort).slice(0, limit);
   }
 
   // Nested tree of comments under a post. Children of a node are sorted
@@ -254,7 +224,7 @@ export class Frontpage {
     }
     const attach = (parentId: string): CommentNode[] => {
       const children = byParent.get(parentId) ?? [];
-      const sorted = sortNodes(children, sort);
+      const sorted = sortByMode(children, sort);
       for (const node of sorted) node.replies = attach(node.id);
       return sorted;
     };
@@ -302,27 +272,14 @@ function controversyScore(up: number, down: number): number {
   return total * balance;
 }
 
-function sortSummaries(items: PostSummary[], sort: SortMode): PostSummary[] {
-  const arr = [...items];
-  if (sort === "new") {
-    arr.sort((a, b) => b.createdAt - a.createdAt);
-  } else if (sort === "controversial") {
-    arr.sort((a, b) => {
-      const ca = controversyScore(a.upvotes, a.downvotes);
-      const cb = controversyScore(b.upvotes, b.downvotes);
-      if (ca !== cb) return cb - ca;
-      return b.createdAt - a.createdAt;
-    });
-  } else {
-    arr.sort((a, b) => {
-      if (a.karma !== b.karma) return b.karma - a.karma;
-      return b.createdAt - a.createdAt;
-    });
-  }
-  return arr;
+interface Sortable {
+  createdAt: number;
+  karma: number;
+  upvotes: number;
+  downvotes: number;
 }
 
-function sortNodes(items: CommentNode[], sort: SortMode): CommentNode[] {
+function sortByMode<T extends Sortable>(items: T[], sort: SortMode): T[] {
   const arr = [...items];
   if (sort === "new") {
     arr.sort((a, b) => b.createdAt - a.createdAt);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -8,15 +8,8 @@ import { runPipeline } from "./runPipeline.js";
 import prisma from "./resources/prisma.js";
 import cryptr from "./resources/cryptr.js";
 import { runRequestSchema } from "./runRequestSchema.js";
-import type {
-  RunRecord,
-  RunStreamEventMap,
-  RunStreamEventName,
-} from "../../shared/contracts.js";
-import {
-  searchOpenRouterModels,
-  trimModelForClient,
-} from "./openrouter-models.js";
+import type { RunRecord, RunStreamEventMap, RunStreamEventName } from "../../shared/contracts.js";
+import { searchOpenRouterModels, trimModelForClient } from "./openrouter-models.js";
 
 const app = express();
 app.use(cors());
@@ -57,10 +50,7 @@ function resolveApiKey(encryptedKey: string): { apiKey: string; mode: "user" | "
 // Typed wrapper around `res.write` so adding an event in the contract is a
 // compile error here until the emit site is updated.
 function makeSseSender(res: Response) {
-  return <K extends RunStreamEventName>(
-    name: K,
-    data: RunStreamEventMap[K]
-  ) => {
+  return <K extends RunStreamEventName>(name: K, data: RunStreamEventMap[K]) => {
     res.write(`event: ${name}\n`);
     res.write(`data: ${JSON.stringify(data)}\n\n`);
   };
@@ -110,9 +100,7 @@ app.get("/api/models", async (req, res) => {
 app.post("/api/encrypt-key", async (req, res) => {
   const parsed = encryptKeySchema.safeParse(req.body);
   if (!parsed.success) {
-    return res
-      .status(400)
-      .json({ error: "invalid request", detail: parsed.error.issues });
+    return res.status(400).json({ error: "invalid request", detail: parsed.error.issues });
   }
   const { key } = parsed.data;
   const isAdmin = key === ADMIN_PASSWORD;
@@ -141,9 +129,7 @@ app.get("/api/profiles", (_req, res) => {
 app.post("/api/run", async (req, res) => {
   const parsed = runRequestSchema.safeParse(req.body);
   if (!parsed.success) {
-    return res
-      .status(400)
-      .json({ error: "invalid request", detail: parsed.error.issues });
+    return res.status(400).json({ error: "invalid request", detail: parsed.error.issues });
   }
   const { encryptedKey, ...request } = parsed.data;
   let resolved: { apiKey: string; mode: "user" | "admin" };
@@ -177,9 +163,7 @@ app.post("/api/run", async (req, res) => {
 app.post("/api/run-stream", async (req, res) => {
   const parsed = runRequestSchema.safeParse(req.body);
   if (!parsed.success) {
-    return res
-      .status(400)
-      .json({ error: "invalid request", detail: parsed.error.issues });
+    return res.status(400).json({ error: "invalid request", detail: parsed.error.issues });
   }
   const { encryptedKey, ...request } = parsed.data;
   let resolved: { apiKey: string; mode: "user" | "admin" };

--- a/server/src/openrouter-models.ts
+++ b/server/src/openrouter-models.ts
@@ -42,8 +42,7 @@ export interface OpenRouterModelSummary {
   created: number;
 }
 
-const OPENROUTER_URL =
-  "https://openrouter.ai/api/v1/models?input_modalities=text";
+const OPENROUTER_URL = "https://openrouter.ai/api/v1/models?input_modalities=text";
 const CACHE_TTL_MS = 5 * 60 * 1000;
 
 interface ModelsCache {

--- a/server/src/profiles.ts
+++ b/server/src/profiles.ts
@@ -95,18 +95,7 @@ const SUFFIXES = [
   "_tx",
 ];
 
-const PREFIXES = [
-  "",
-  "the_",
-  "real_",
-  "u_",
-  "iam_",
-  "mr_",
-  "ms_",
-  "lord_",
-  "dr_",
-  "big_",
-];
+const PREFIXES = ["", "the_", "real_", "u_", "iam_", "mr_", "ms_", "lord_", "dr_", "big_"];
 
 // Build a reddit-style username deterministically from the profile id.
 // Real reddit handles are messy — first names, weird suffixes, leetspeak,
@@ -114,8 +103,17 @@ const PREFIXES = [
 // agents handles that read like a real comment section without needing
 // the LLM to invent them.
 function deriveUsername(id: string, fullName: string, age: number): string {
-  const first = fullName.split(/\s+/)[0]?.toLowerCase().replace(/[^a-z]/g, "") ?? "user";
-  const last = fullName.split(/\s+/).slice(-1)[0]?.toLowerCase().replace(/[^a-z]/g, "") ?? "x";
+  const first =
+    fullName
+      .split(/\s+/)[0]
+      ?.toLowerCase()
+      .replace(/[^a-z]/g, "") ?? "user";
+  const last =
+    fullName
+      .split(/\s+/)
+      .slice(-1)[0]
+      ?.toLowerCase()
+      .replace(/[^a-z]/g, "") ?? "x";
   const initial = last[0] ?? "x";
   const yearTail = String(2025 - age).slice(-2);
   const h = hash(id);

--- a/server/src/report.ts
+++ b/server/src/report.ts
@@ -49,18 +49,17 @@ function serializeSnapshot(snapshot: FrontpageSnapshot): string {
   for (const p of snapshot.posts) {
     const header = `## [karma ${p.karma}] "${p.post.title}" — u/${p.post.authorUsername}`;
     const body = p.post.body.trim().length > 0 ? `\n\n${p.post.body.trim()}` : "";
-    const commentLines = p.comments.length > 0
-      ? `\n\nComments:\n${p.comments.map((c) => serializeComment(c, 0)).join("\n")}`
-      : "\n\n(no comments)";
+    const commentLines =
+      p.comments.length > 0
+        ? `\n\nComments:\n${p.comments.map((c) => serializeComment(c, 0)).join("\n")}`
+        : "\n\n(no comments)";
     blocks.push(`${header}${body}${commentLines}`);
   }
   return blocks.join("\n\n---\n\n");
 }
 
 function extractCost(providerMetadata: unknown): number {
-  const pm = providerMetadata as
-    | { openrouter?: { usage?: { cost?: number } } }
-    | undefined;
+  const pm = providerMetadata as { openrouter?: { usage?: { cost?: number } } } | undefined;
   const cost = pm?.openrouter?.usage?.cost;
   return typeof cost === "number" ? cost : 0;
 }

--- a/server/src/resources/cryptr.ts
+++ b/server/src/resources/cryptr.ts
@@ -2,9 +2,7 @@ import Cryptr from "cryptr";
 
 const masterKey = process.env.MASTER_ENCRYPTION_KEY;
 if (!masterKey || masterKey.length < 16) {
-  throw new Error(
-    "MASTER_ENCRYPTION_KEY environment variable is required (at least 16 chars)"
-  );
+  throw new Error("MASTER_ENCRYPTION_KEY environment variable is required (at least 16 chars)");
 }
 
 const cryptr = new Cryptr(masterKey);

--- a/server/src/runPipeline.ts
+++ b/server/src/runPipeline.ts
@@ -137,9 +137,7 @@ export async function runPipeline(opts: PipelineOptions): Promise<PipelineResult
   onReportStart?.();
   activity.push({ kind: "phase", label: "Writing report…", tone: "info" });
 
-  const reportModel = createOpenRouter({ apiKey }).chat(
-    request.modelId ?? DEFAULT_MODEL_ID
-  );
+  const reportModel = createOpenRouter({ apiKey }).chat(request.modelId ?? DEFAULT_MODEL_ID);
   const report = await generateReport({
     model: reportModel,
     source: request.source,

--- a/server/src/runSimulation.ts
+++ b/server/src/runSimulation.ts
@@ -67,9 +67,7 @@ export interface SimulationResult {
   };
 }
 
-export async function runSimulation(
-  opts: SimulationOptions
-): Promise<SimulationResult> {
+export async function runSimulation(opts: SimulationOptions): Promise<SimulationResult> {
   const {
     source,
     pool,
@@ -88,9 +86,7 @@ export async function runSimulation(
   if (!apiKey) throw new Error("apiKey is required");
   if (agentCount < 1) throw new Error("agentCount must be at least 1");
   if (pool.length < agentCount) {
-    throw new Error(
-      `pool has ${pool.length} profiles but ${agentCount} were requested`
-    );
+    throw new Error(`pool has ${pool.length} profiles but ${agentCount} were requested`);
   }
 
   const openrouter = createOpenRouter({ apiKey });
@@ -161,9 +157,7 @@ export async function runSimulation(
       results.push(result);
       onAgentDone?.(result);
       const status = result.errored ? `ERR ${result.error}` : `${result.steps} steps`;
-      console.log(
-        `  ← u/${profile.username} done (${status}, $${result.costUsd.toFixed(6)})`
-      );
+      console.log(`  ← u/${profile.username} done (${status}, $${result.costUsd.toFixed(6)})`);
       if (mode === "requeue") queue.push(profile);
 
       if (result.errored) {
@@ -182,9 +176,7 @@ export async function runSimulation(
         // entire budget at zero latency.
         const remainingMs = deadline - Date.now();
         if (remainingMs > 0) {
-          await new Promise((r) =>
-            setTimeout(r, Math.min(ERROR_BACKOFF_MS, remainingMs))
-          );
+          await new Promise((r) => setTimeout(r, Math.min(ERROR_BACKOFF_MS, remainingMs)));
         }
       } else {
         consecutiveErrors = 0;

--- a/server/src/tools.ts
+++ b/server/src/tools.ts
@@ -1,11 +1,6 @@
 import { tool } from "ai";
 import { z } from "zod";
-import {
-  Frontpage,
-  SelfVoteError,
-  UnknownEntityError,
-  type SortMode,
-} from "./frontpage.js";
+import { Frontpage, SelfVoteError, UnknownEntityError, type SortMode } from "./frontpage.js";
 import type { ActivityEvent } from "../../shared/contracts.js";
 
 export type { ActivityEvent } from "../../shared/contracts.js";
@@ -20,16 +15,14 @@ export interface ToolContext {
 
 const sortSchema = z
   .enum(["top", "new", "controversial"])
-  .describe("Sort order. 'top' = most upvoted, 'new' = most recent, 'controversial' = most debated.");
+  .describe(
+    "Sort order. 'top' = most upvoted, 'new' = most recent, 'controversial' = most debated."
+  );
 
 // Centralized error wrapper so every tool returns a consistent
 // `{ error: string }` shape instead of throwing inside the AI SDK
 // step loop. The model gets the message and can usefully retry.
-function safeRun<T>(
-  ctx: ToolContext,
-  toolName: string,
-  fn: () => T
-): T | { error: string } {
+function safeRun<T>(ctx: ToolContext, toolName: string, fn: () => T): T | { error: string } {
   try {
     return fn();
   } catch (err) {
@@ -57,9 +50,7 @@ export function buildTools(ctx: ToolContext) {
         limit: z.number().int().min(1).max(50).default(25),
       }),
       execute: async ({ sort, limit }) =>
-        safeRun(ctx, "get_posts", () =>
-          ctx.fp.listPosts({ sort: sort as SortMode, limit })
-        ),
+        safeRun(ctx, "get_posts", () => ctx.fp.listPosts({ sort: sort as SortMode, limit })),
     }),
 
     get_post: tool({
@@ -100,9 +91,7 @@ export function buildTools(ctx: ToolContext) {
         sort: sortSchema.default("top"),
       }),
       execute: async ({ post_id, sort }) =>
-        safeRun(ctx, "get_comments", () =>
-          ctx.fp.getCommentTree(post_id, sort as SortMode)
-        ),
+        safeRun(ctx, "get_comments", () => ctx.fp.getCommentTree(post_id, sort as SortMode)),
     }),
 
     create_post: tool({

--- a/server/tests/encryptedKey.test.ts
+++ b/server/tests/encryptedKey.test.ts
@@ -9,9 +9,7 @@ const hex = (n: number) => "a".repeat(n);
 
 describe("encryptedKeySchema", () => {
   it("accepts a well-formed hex blob at the minimum length", () => {
-    expect(encryptedKeySchema.safeParse(hex(ENCRYPTED_KEY_MIN)).success).toBe(
-      true
-    );
+    expect(encryptedKeySchema.safeParse(hex(ENCRYPTED_KEY_MIN)).success).toBe(true);
   });
 
   it("accepts a typical-length blob (admin password sized plaintext)", () => {
@@ -20,9 +18,7 @@ describe("encryptedKeySchema", () => {
   });
 
   it("accepts a blob at the maximum length", () => {
-    expect(encryptedKeySchema.safeParse(hex(ENCRYPTED_KEY_MAX)).success).toBe(
-      true
-    );
+    expect(encryptedKeySchema.safeParse(hex(ENCRYPTED_KEY_MAX)).success).toBe(true);
   });
 
   it("rejects an empty string", () => {
@@ -30,15 +26,11 @@ describe("encryptedKeySchema", () => {
   });
 
   it("rejects a blob shorter than the cryptr prefix", () => {
-    expect(
-      encryptedKeySchema.safeParse(hex(ENCRYPTED_KEY_MIN - 2)).success
-    ).toBe(false);
+    expect(encryptedKeySchema.safeParse(hex(ENCRYPTED_KEY_MIN - 2)).success).toBe(false);
   });
 
   it("rejects an oversized blob", () => {
-    expect(
-      encryptedKeySchema.safeParse(hex(ENCRYPTED_KEY_MAX + 2)).success
-    ).toBe(false);
+    expect(encryptedKeySchema.safeParse(hex(ENCRYPTED_KEY_MAX + 2)).success).toBe(false);
   });
 
   it("rejects non-hex characters", () => {
@@ -57,9 +49,7 @@ describe("encryptedKeySchema", () => {
   });
 
   it("rejects odd-length hex", () => {
-    expect(
-      encryptedKeySchema.safeParse(hex(ENCRYPTED_KEY_MIN + 1)).success
-    ).toBe(false);
+    expect(encryptedKeySchema.safeParse(hex(ENCRYPTED_KEY_MIN + 1)).success).toBe(false);
   });
 
   it("accepts a real cryptr-shaped blob", async () => {

--- a/server/tests/frontpage.test.ts
+++ b/server/tests/frontpage.test.ts
@@ -1,9 +1,5 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import {
-  Frontpage,
-  SelfVoteError,
-  UnknownEntityError,
-} from "../src/frontpage.js";
+import { Frontpage, SelfVoteError, UnknownEntityError } from "../src/frontpage.js";
 
 // Deterministic clock so we can assert ordering by createdAt without sleeps.
 function makeClock() {
@@ -63,9 +59,7 @@ describe("Frontpage", () => {
     });
 
     it("rejects replies to unknown entities", () => {
-      expect(() => fp.createComment("bob", "missing", "x")).toThrow(
-        UnknownEntityError
-      );
+      expect(() => fp.createComment("bob", "missing", "x")).toThrow(UnknownEntityError);
     });
   });
 
@@ -171,11 +165,7 @@ describe("Frontpage", () => {
     });
 
     it("includes preview, comment count, and votes per post", () => {
-      const post = fp.createPost(
-        "alice",
-        "title",
-        "x".repeat(500)
-      );
+      const post = fp.createPost("alice", "title", "x".repeat(500));
       fp.createComment("bob", post.id, "c1");
       fp.createComment("carol", post.id, "c2");
       fp.vote("bob", post.id, "up");


### PR DESCRIPTION
Closes #8

## Summary
- Rewrite the README so it matches reality. The previous version still claimed state was in-memory only with no database, and referenced `client/src/App.tsx`, which no longer exists. Stack, project layout, env vars, API table, and SSE event list now reflect the Prisma + SQLite + shared/contracts world we actually live in.
- Add a Prettier baseline: `.prettierrc.json` + `.prettierignore` at the repo root, plus `format` / `format:check` scripts in both packages. Ran `prettier --write` once so the baseline is real and `format:check` is green from this commit forward. Intentionally no ESLint — `tsc -b` is the source of truth for correctness, Prettier handles style.
- Trim `Frontpage` public surface: drop the unused `EntityKind` export and the unused `listComments()` method, make `countCommentsFor` private (only `listPosts` uses it), and collapse the duplicated `sortSummaries` / `sortNodes` helpers into a single `sortByMode<T extends Sortable>`. Same Reddit semantics, less duplication.

## Acceptance criteria
- [x] README accurately describes Prisma/SQLite persistence and current client file layout.
- [x] The repo has a clear formatting story (Prettier config + scripts in both packages, baseline applied).
- [x] `Frontpage` exposes only intentional public API surface.
- [x] Existing server tests continue to pass.

## Test plan
- [x] `cd server && npm test` — 32/32 pass.
- [x] `cd client && npm test` — 5/5 pass.
- [x] `cd client && npm run build` — clean tsc + vite build.
- [x] `npm run format:check` in both packages — both green.